### PR TITLE
Removed meaningless ord and eq derives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,18 +34,7 @@ static PUB_KEYS: Lazy<PubKeysMap> = Lazy::new(|| PubKeysMap::new());
 //#[derive(Serialize, Deserialize, Debug, PostgresType)]
 //#[derive(Serialize, Deserialize, Debug)]
 #[repr(transparent)]
-#[derive(
-    Clone,
-    Debug,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    PostgresEq,
-    PostgresOrd,
-    PostgresHash
-)]
+#[derive( Clone, Debug)]
 //#[inoutfuncs]
 struct Enigma {
     value: String,


### PR DESCRIPTION
ord and eq functions need the content to be decrypted to have a meaning Since payload is always encrypted, all comparissons on those encrypted values will necessarily be wrong
The same for hashing. There same un encrypted value will always produce different encrypted values so all hash searches will always fail. In case comparisson functions are to be enabled, they MUST return error unless both private keys are present. This can't be acomplished with derive macros.
Hashing functions should not be enabled even if the private key is present because a hash index will provide unwanted evidence about same records even thoug their content is unknown. In case hashing function is to be enabled, it should always return error.